### PR TITLE
Spice and Tool Rack Recipes show Milk Jars

### DIFF
--- a/cookingforblockheads/spice_rack.md
+++ b/cookingforblockheads/spice_rack.md
@@ -5,7 +5,7 @@ The Spice Rack holds up to nine ingredients that will be made available to your 
 
 Check the [Cooking Table](cookingforblockheads:cooking_table) for more information on Multiblock Kitchens.
 
-![cookingforblockheads:milk_jar](crafting://null,null,null,null,any:wooden_slab,null,null,null,null)
+![cookingforblockheads:spice_rack](crafting://null,null,null,null,any:wooden_slab,null,null,null,null)
 
 ## Interface
 ![cookingforblockheads/images/spice_rack.png](imagemap://Storage Slots=14,34,320,32;Player Inventory=16,100,320,148)

--- a/cookingforblockheads/tool_rack.md
+++ b/cookingforblockheads/tool_rack.md
@@ -5,7 +5,7 @@ The Tool Rack holds up to two tools that will be made available to your multiblo
 
 Check the [Cooking Table](cookingforblockheads:cooking_table) for more information on Multiblock Kitchens.
 
-![cookingforblockheads:milk_jar](crafting://null,null,null,any:wooden_slab,any:wooden_slab,any:wooden_slab,minecraft:iron_nugget,null,minecraft:iron_nugget)
+![cookingforblockheads:tool_rack](crafting://null,null,null,any:wooden_slab,any:wooden_slab,any:wooden_slab,minecraft:iron_nugget,null,minecraft:iron_nugget)
 
 ## Usage
 Right-click the tool rack with an item in your hand to put the item on the tool rack. Right-clicking the tool rack when it already has an item in that spot will retrieve or swap the item out.


### PR DESCRIPTION
closes #6 
The [tool rack](http://blay09.net/mods/cookingforblockheads/tool_rack) and [spice rack](http://blay09.net/mods/cookingforblockheads/spice_rack) show a milk jar as the output for their recipes. This PR shows their correct item.